### PR TITLE
Fix update last_gathered_entries

### DIFF
--- a/insights_analytics_collector/__init__.py
+++ b/insights_analytics_collector/__init__.py
@@ -1,6 +1,8 @@
 from .collector import Collector
 from .package import Package
+from .collection_json import CollectionJSON
+from .collection_csv import CollectionCSV
 from .csv_file_splitter import CsvFileSplitter
 from .decorators import register, slicing
 
-__all__ = ['Collector', 'Package', 'CsvFileSplitter', 'register', 'slicing']
+__all__ = ['Collector', 'Package', 'CsvFileSplitter', 'CollectionCSV', 'CollectionJSON', 'register', 'slicing']

--- a/insights_analytics_collector/collection.py
+++ b/insights_analytics_collector/collection.py
@@ -101,8 +101,11 @@ class Collection:
             return
 
         if self.gathering_successful:
-            previous = updates_dict['keys'].get(self.key)
-            updates_dict['keys'][self.key] = max(previous, self.until)
+            previous = updates_dict['keys'].get(self.key, None)
+            if previous is None:
+                updates_dict['keys'][self.key] = self.until
+            else:
+                updates_dict['keys'][self.key] = max(previous, self.until)
         else:
             updates_dict['locked'].add(self.key)
 

--- a/insights_analytics_collector/collector.py
+++ b/insights_analytics_collector/collector.py
@@ -405,7 +405,7 @@ class Collector:
 
         for _, packages in self.packages.items():
             for package in packages:
-                package.update_last_gathered_entries(last_gathered_updates['keys'])
+                package.update_last_gathered_entries(last_gathered_updates)
 
         self.last_gathered_entries.update(last_gathered_updates)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AA-1076

issue in the function `update_last_gathered_entries` of file `collection.py`
```
     99     def update_last_gathered_entries(self, updates_dict):
    100         if self.key in updates_dict['locked']:
    101             return
    102
    103         if self.gathering_successful:
    104             previous = updates_dict['keys'].get(self.key)
    105             updates_dict['keys'][self.key] = max(previous, self.until)
    106         else:
    107             updates_dict['locked'].add(self.key)
```

- the updates_dict is the keys here, `updates_dict['locked']` will throw `KeyError`
- In line 104: previous might be `None`, and the follow max will raise error too