### PR TITLE
Hybrid full/incremental sync

### DIFF
--- a/insights_analytics_collector/collector.py
+++ b/insights_analytics_collector/collector.py
@@ -434,6 +434,11 @@ class Collector:
             for package in packages:
                 package.update_last_gathered_entries(last_gathered_updates)
 
+        # Locked key means that gathering wasn't successful at least once.
+        # Full sync timestamp can't be updated (if present)
+        for unsuccessful_key in last_gathered_updates["locked"]:
+            last_gathered_updates.pop(f"{unsuccessful_key}_full", None)
+
         self.last_gathered_entries.update(last_gathered_updates["keys"])
 
         self._save_last_gathered_entries(self.last_gathered_entries)

--- a/insights_analytics_collector/decorators.py
+++ b/insights_analytics_collector/decorators.py
@@ -6,6 +6,7 @@ def register(
     config=False,
     fnc_slicing=None,
     shipping_group="default",
+    full_sync_interval_days=None,
 ):
     """
     A decorator used to register a function as a metric collector.
@@ -29,6 +30,7 @@ def register(
         f.__insights_analytics_config__ = config  # config
         f.__insights_analytics_fnc_slicing__ = fnc_slicing
         f.__insights_analytics_shipping_group__ = shipping_group
+        f.__insights_analytics_full_sync_interval_days__ = full_sync_interval_days
 
         return f
 

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
     packages=find_packages(),
     include_package_data=False,
     install_requires=["django", "requests"],
-    tests_require=["pytest", "pytest-mock"],
+    tests_require=["pytest", "pytest-mock", "pytz"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+settings.configure(USE_TZ=True)

--- a/tests/functional/collector_module4_slicing.py
+++ b/tests/functional/collector_module4_slicing.py
@@ -1,0 +1,67 @@
+from insights_analytics_collector import register
+from tests.functional.helpers import (
+    TIMESTAMP_CSV_LINE_LENGTH,
+    full_sync_slicing,
+    one_day_slicing,
+    timestamp_csv,
+)
+
+
+@register("config", "1.0", description="CONFIG", config=True)
+def config(since, **kwargs):
+    return {"version": "1.0"}
+
+
+@register(
+    "csv_one_day_slicing_1",
+    "1.0",
+    format="csv",
+    description="CSVs splitted by date",
+    fnc_slicing=one_day_slicing,
+)
+def csv_one_day_slicing_1(since, full_path, until, **kwargs):
+    return timestamp_csv(
+        full_path,
+        "csv_one_day_slicing_1",
+        1,
+        2 * TIMESTAMP_CSV_LINE_LENGTH,
+        since=since,
+        until=until,
+    )
+
+
+@register(
+    "csv_one_day_slicing_2",
+    "1.0",
+    format="csv",
+    description="CSVs splitted by size and date",
+    fnc_slicing=one_day_slicing,
+)
+def csv_one_day_slicing_2(since, full_path, until, **kwargs):
+    return timestamp_csv(
+        full_path,
+        "csv_one_day_slicing_2",
+        2,
+        2 * TIMESTAMP_CSV_LINE_LENGTH,
+        since=since,
+        until=until,
+    )
+
+
+@register(
+    "csv_full_sync_slicing_1",
+    "1.0",
+    format="csv",
+    description="CSVs splitted by date",
+    fnc_slicing=full_sync_slicing,
+    full_sync_interval_days=5,
+)
+def csv_full_sync_slicing_1(since, full_path, until, **kwargs):
+    return timestamp_csv(
+        full_path,
+        "csv_full_sync_slicing_1",
+        1,
+        2 * TIMESTAMP_CSV_LINE_LENGTH,
+        since=since,
+        until=until,
+    )

--- a/tests/functional/helpers.py
+++ b/tests/functional/helpers.py
@@ -1,25 +1,84 @@
 import os
 
+from django.utils.timezone import now, timedelta
 from insights_analytics_collector import CsvFileSplitter
 
+TIMESTAMP_CSV_LINE_LENGTH = 40
 
-def trivial_slicing(key, since, until, last_gather):
+
+def trivial_slicing(key, last_gather, since, until, **kwargs):
     return [(since, until)]
 
 
-def simple_csv(full_path, file_name, files_cnt, max_data_size):
+def one_day_slicing(key, last_gather, since, until, **kwargs):
+    since = since.replace(hour=0, minute=0, second=0, microsecond=0)
+    until = until.replace(hour=0, minute=0, second=0, microsecond=0)
+    start, end = since, None
+    while start < until:
+        end = min(start + timedelta(days=1), until)
+        yield (start, end)
+        start = end
+
+
+def full_sync_slicing(key, last_gather, full_sync_enabled=False, since=None, **kwargs):
+    """
+    If full_sync_enabled is:
+        - True: Yields 10 time slices in 1-day intervals
+        - False: Yields slices since 'since' in 1-day intervals
+    """
+    current_time = now().replace(hour=0, minute=0, second=0, microsecond=0)
+    if full_sync_enabled:
+        start = current_time - timedelta(days=10)
+        start = start.replace(hour=0, minute=0, second=0, microsecond=0)
+    else:
+        start = since.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    while start < current_time:
+        end = start + timedelta(days=1)
+        yield (start, end)
+        start = end
+
+
+def csv_generator(full_path, file_name, files_cnt, max_data_size, header, line):
     file_path = get_file_path(full_path, file_name)
     file = CsvFileSplitter(filespec=file_path, max_file_size=max_data_size)
-    header = "Col1,Col2\n"
-    line = "1234,6789\n"
 
     # create required number of files (decrease by headers - it's CSV)
     file.write(header)
-    for _ in range(files_cnt * int(max_data_size / 10) - files_cnt):
+    for _ in range(files_cnt * int(max_data_size / len(line)) - files_cnt):
         file.write(line)
 
     return file.file_list()
 
 
+def simple_csv(full_path, file_name, files_cnt, max_data_size):
+    """CSVs with line length 10 bytes"""
+    header = "Col1,Col2\n"  # 10 chars
+    line = "1234,6789\n"  # 10 chars
+    return csv_generator(full_path, file_name, files_cnt, max_data_size, header, line)
+
+
+def timestamp_csv(full_path, file_name, files_cnt, max_data_size, since, until):
+    """CSVs with line length 40 bytes"""
+    header = "since______________,until______________\n"  # 40 chars
+    line = [
+        since.strftime("%Y,%m,%d,%H,00,00"),  # 19 chars
+        until.strftime("%Y,%m,%d,%H,00,00"),
+    ]  # 19 chars
+    line = f"{','.join(line)}\n"  # +2 = 40 chars
+
+    return csv_generator(full_path, file_name, files_cnt, max_data_size, header, line)
+
+
 def get_file_path(path, table):
     return os.path.join(path, table + "_table.csv")
+
+
+def decode_csv_line(line):
+    return line.decode("utf-8").replace("\r", "").replace("\n", "").split(",")
+
+
+def assert_common_files(files):
+    assert "./config.json" in files.keys()
+    assert "./manifest.json" in files.keys()
+    assert "./data_collection_status.csv" in files.keys()

--- a/tests/functional/test_slicing.py
+++ b/tests/functional/test_slicing.py
@@ -1,0 +1,129 @@
+import datetime
+import tarfile
+
+import pytest
+import pytz
+import tests.functional.collector_module4_slicing
+from django.utils.timezone import now, timedelta
+from tests.classes.analytics_collector import AnalyticsCollector
+from tests.functional.helpers import assert_common_files, decode_csv_line
+
+
+@pytest.fixture
+def collector(mocker):
+    """
+    Collector with registered module `collector_module4_slicing`.
+    It's designed to use non-trivial slicing functions
+    """
+    collector = AnalyticsCollector(
+        collector_module=tests.functional.collector_module4_slicing,
+        collection_type=AnalyticsCollector.DRY_RUN,
+    )
+    mocker.patch.object(collector, "_is_valid_license", return_value=True)
+
+    return collector
+
+
+def test_slices_by_date(collector):
+    """
+    Slicing by fnc_slicing function `one_day_slicing`.
+    Splits data to 10 days/files.
+    """
+    days_to_collect = 10
+
+    until = now().replace(hour=0, minute=0, second=0, microsecond=0)
+    since = until - timedelta(days=days_to_collect)
+
+    tgz_files = collector.gather(
+        subset=["config", "csv_one_day_slicing_1"], since=since, until=until
+    )
+
+    assert len(tgz_files) == days_to_collect
+
+    idx = 0
+    while since < until:
+        files = {}
+        with tarfile.open(tgz_files[idx], "r:gz") as archive:
+            for member in archive.getmembers():
+                files[member.name] = archive.extractfile(member)
+
+            assert_common_files(files)
+            assert "./csv_one_day_slicing_1.csv" in files.keys()
+
+            lines = files["./csv_one_day_slicing_1.csv"].readlines()
+            _header = lines.pop(0)
+            row = decode_csv_line(lines[0])
+
+            csv_since = datetime.datetime(
+                int(row[0]),
+                int(row[1]),
+                int(row[2]),
+                int(row[3]),
+                int(row[4]),
+                int(row[5]),
+                tzinfo=pytz.utc,
+            )
+            csv_until = datetime.datetime(
+                int(row[6]),
+                int(row[7]),
+                int(row[8]),
+                int(row[9]),
+                int(row[10]),
+                int(row[11]),
+                tzinfo=pytz.utc,
+            )
+
+            assert csv_since == since
+            assert csv_until == since + timedelta(days=1)
+
+        idx += 1
+        since += timedelta(days=1)
+
+
+def test_slices_by_date_and_size(collector):
+    """
+    Slicing by fnc_slicing function `one_day_slicing()`.
+    Splits data to 10 days/files.
+    Also splits each day to 2 files by size (CsvFileSplitter)
+    => total 20 files
+    """
+    days_to_collect = 10
+
+    until = now().replace(hour=0, minute=0, second=0, microsecond=0)
+    since = until - timedelta(days=days_to_collect)
+
+    tgz_files = collector.gather(
+        subset=["config", "csv_one_day_slicing_2"], since=since, until=until
+    )
+
+    assert len(tgz_files) == days_to_collect * 2
+
+
+@pytest.mark.parametrize("last_sync_days_ago", [4, 6])
+def test_slices_by_full_sync(mocker, collector, last_sync_days_ago):
+    """
+    In the collector method `csv_full_sync_slicing_1()` there is 5 days interval for full sync
+    if `last_sync_days_ago` is:
+    - 4 days ago, it uses `since` (7 days ago)
+    - 6 days ago, it uses slicing interval (10 days ago) (in `full_sync_slicing()`)
+
+    """
+    last_gathered_entries = {
+        "csv_full_sync_slicing_1": (now() - timedelta(days=7)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ),
+        "csv_full_sync_slicing_1_full": now() - timedelta(days=last_sync_days_ago),
+    }
+    mocker.patch.object(
+        collector, "_load_last_gathered_entries", return_value=last_gathered_entries
+    )
+
+    tgz_files = collector.gather(
+        subset=["config", "csv_full_sync_slicing_1"],
+        since=last_gathered_entries["csv_full_sync_slicing_1"],
+    )
+
+    if last_sync_days_ago == 4:
+        assert len(tgz_files) == 7
+    else:
+        assert len(tgz_files) == 10


### PR DESCRIPTION
Adds options for hybrid full/incremental sync. 
It adds `full_sync_interval_days` to the decorator `@register`

If the interval is longer, sends `full_sync_enabled=True` to the slicing function `fnc_slicing`

Also implemented in Controller's core.py for HostMetric hybrid sync.

https://issues.redhat.com/browse/AA-1647